### PR TITLE
chore: remove private field from package.json to enable npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "flickview",
-  "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Removed "private": true field from package.json
- This change enables npm publish for flickview library
- Previously, npm publish was blocked due to the private flag